### PR TITLE
Implement a command line interface for tasks3

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -10,3 +10,4 @@ twine==3.2.0
 Click==7.1.2
 pytest==5.4.3
 pytest-runner==5.2
+black==19.10b0

--- a/setup.py
+++ b/setup.py
@@ -4,50 +4,54 @@
 
 from setuptools import setup, find_packages
 
-with open('README.rst') as readme_file:
+with open("README.rst") as readme_file:
     readme = readme_file.read()
 
-with open('HISTORY.rst') as history_file:
+with open("HISTORY.rst") as history_file:
     history = history_file.read()
 
-requirements = ['Click>=7.0', 'click-plugins==1.1.1', 'click-command-tree==1.1.0']
+requirements = [
+    "Click>=7.0",
+    "click-plugins==1.1.1",
+    "click-command-tree==1.1.0",
+]
 
-setup_requirements = ['pytest-runner', ]
+setup_requirements = [
+    "pytest-runner",
+]
 
-test_requirements = ['pytest>=3', ]
+test_requirements = [
+    "pytest>=3",
+]
 
 setup(
     author="Harsh Parekh",
-    author_email='harsh_parekh@outlook.com',
-    python_requires='>=3.5',
+    author_email="harsh_parekh@outlook.com",
+    python_requires=">=3.5",
     classifiers=[
-        'Development Status :: 2 - Pre-Alpha',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
-        'Natural Language :: English',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
+        "Development Status :: 2 - Pre-Alpha",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+        "Natural Language :: English",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
     ],
     description="A commandline tool to create and manage tasks and todos.",
-    entry_points={
-        'console_scripts': [
-            'tasks3=tasks3.cli:main',
-        ],
-    },
+    entry_points={"console_scripts": ["tasks3=tasks3.cli:main",],},
     install_requires=requirements,
     license="GNU General Public License v3",
-    long_description=readme + '\n\n' + history,
+    long_description=readme + "\n\n" + history,
     include_package_data=True,
-    keywords='tasks3',
-    name='tasks3',
-    packages=find_packages(include=['tasks3', 'tasks3.*']),
+    keywords="tasks3",
+    name="tasks3",
+    packages=find_packages(include=["tasks3", "tasks3.*"]),
     setup_requires=setup_requirements,
-    test_suite='tests',
+    test_suite="tests",
     tests_require=test_requirements,
-    url='https://github.com/hXtreme/tasks3',
-    version='0.0.7',
+    url="https://github.com/hXtreme/tasks3",
+    version="0.0.7",
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('README.rst') as readme_file:
 with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
-requirements = ['Click>=7.0', ]
+requirements = ['Click>=7.0', 'click-plugins==1.1.1', 'click-command-tree==1.1.0']
 
 setup_requirements = ['pytest-runner', ]
 

--- a/tasks3/__init__.py
+++ b/tasks3/__init__.py
@@ -1,5 +1,5 @@
-"""Top-level package for tasks3."""
+"""tasks3 is a commandline tool to create and manage tasks and todo lists."""
 
 __author__ = """Harsh Parekh"""
-__email__ = 'harsh_parekh@outlook.com'
-__version__ = '0.0.7'
+__email__ = "harsh_parekh@outlook.com"
+__version__ = "0.0.7"

--- a/tasks3/__init__.py
+++ b/tasks3/__init__.py
@@ -1,4 +1,4 @@
-"""tasks3 is a commandline tool to create and manage tasks and todo lists."""
+"""tasks3 is a commandline tool to create and manage tasks and todo lists"""
 
 __author__ = """Harsh Parekh"""
 __email__ = "harsh_parekh@outlook.com"

--- a/tasks3/cli.py
+++ b/tasks3/cli.py
@@ -124,43 +124,6 @@ def db():
 
 
 @db.command()
-@click.argument(
-    "db",
-    type=click.Path(dir_okay=False, writable=True),
-    default=os.path.join(click.get_app_dir(__name__), "tasks.db"),
-)
-def init(db: str):
-    """Initialize and setup the database at db.
-
-    If db is not provide a database at system's default app directory is used.
-    """
-    pass
-
-
-@db.command()
-@click.confirmation_option(prompt="Are you sure you want to purge all tasks?")
-@click.argument(
-    "db",
-    type=click.Path(dir_okay=False, writable=True),
-    default=os.path.join(click.get_app_dir(__name__), "tasks.db"),
-)
-def purge(db: str):
-    pass
-
-
-@db.command()
-@click.confirmation_option(prompt="Are you sure you want to drop the database?")
-@click.argument(
-    "db",
-    type=click.Path(dir_okay=False, writable=True),
-    default=os.path.join(click.get_app_dir(__name__), "tasks.db"),
-)
-def drop(db: str):
-    pass
-
-
-@db.command()
-@click.confirmation_option(prompt="Are you sure you want to move the database?")
 @click.option(
     "--db",
     type=click.Path(dir_okay=False, writable=True),
@@ -168,6 +131,46 @@ def drop(db: str):
     show_default=True,
     help="Location of database",
 )
+def init(db: str):
+    """Initialize and setup the database at db."""
+    pass
+
+
+@db.command()
+@click.option(
+    "--db",
+    type=click.Path(dir_okay=False, writable=True),
+    default=os.path.join(click.get_app_dir(__name__), "tasks.db"),
+    show_default=True,
+    help="Location of database",
+)
+@click.confirmation_option(prompt="Are you sure you want to purge all tasks?")
+def purge(db: str):
+    pass
+
+
+@db.command()
+@click.option(
+    "--db",
+    type=click.Path(dir_okay=False, writable=True),
+    default=os.path.join(click.get_app_dir(__name__), "tasks.db"),
+    show_default=True,
+    help="Location of database",
+)
+@click.confirmation_option(prompt="Are you sure you want to drop the database?")
+def drop(db: str):
+    pass
+
+
+@db.command()
+@click.option(
+    "--db",
+    type=click.Path(dir_okay=False, writable=True),
+    default=os.path.join(click.get_app_dir(__name__), "tasks.db"),
+    show_default=True,
+    help="Location of database",
+)
+@click.confirmation_option(prompt="Are you sure you want to move the database?")
 @click.argument(
     "dest_db",
     type=click.Path(dir_okay=False, writable=True),

--- a/tasks3/cli.py
+++ b/tasks3/cli.py
@@ -6,13 +6,27 @@ import click
 
 @click.group()
 @click.version_option()
-def main(args=None):
+@click.option(
+    "--db",
+    type=click.Path(dir_okay=False, writable=True),
+    default=os.path.join(click.get_app_dir(__name__), "tasks.db"),
+    show_default=True,
+    help="Location of tasks database.",
+)
+@click.pass_context
+def main(ctx: click.core.Context, db: str):
     """tasks3 is a commandline tool to create and manage tasks and todo lists"""
+
+    ctx.ensure_object(dict)
+
+    ctx.obj["DB"] = db
+    print(type(ctx))
     return 0
 
 
 @main.group()
-def task():
+@click.pass_context
+def task(ctx: click.core.Context):
     """Manage a task"""
     pass
 
@@ -27,7 +41,8 @@ def task():
     show_default=True,
 )
 @click.argument("id", type=str)
-def show(format: str, id: str):
+@click.pass_context
+def show(ctx: click.core.Context, format: str, id: str):
     """Show the task in the specified FORMAT
 
     ID is the id of the Task to be printed.
@@ -40,7 +55,8 @@ def show(format: str, id: str):
     "--yes", default=False, help="Overwrite task data without confirmation?",
 )
 @click.argument("id", type=str)
-def edit(yes: bool, id: str):
+@click.pass_context
+def edit(ctx: click.core.Context, yes: bool, id: str):
     """Edit a Task
 
     ID is the id of the Task to be edited.
@@ -53,7 +69,8 @@ def edit(yes: bool, id: str):
     "--yes", default=False, help="Delete task without confirmation?",
 )
 @click.argument("id", type=str)
-def remove(yes: bool, id: str):
+@click.pass_context
+def remove(ctx: click.core.Context, yes: bool, id: str):
     """Remove a Task
 
     ID is the id of the Task to be removed.
@@ -100,7 +117,9 @@ def remove(yes: bool, id: str):
 @click.option(
     "--yes", default=False, help="Create task without confirmation?",
 )
+@click.pass_context
 def add(
+    ctx: click.core.Context,
     title: str,
     urgency: int,
     importance: int,
@@ -114,67 +133,44 @@ def add(
 
 
 @main.group()
-def db():
+@click.pass_context
+def db(ctx: click.core.Context):
     """Manage tasks3's database"""
     pass
 
 
 @db.command()
-@click.option(
-    "--db",
-    type=click.Path(dir_okay=False, writable=True),
-    default=os.path.join(click.get_app_dir(__name__), "tasks.db"),
-    show_default=True,
-    help="Location of database.",
-)
-def init(db: str):
+@click.pass_context
+def init(ctx: click.core.Context):
     """Initialize and setup the database"""
     pass
 
 
 @db.command()
-@click.option(
-    "--db",
-    type=click.Path(dir_okay=False, writable=True),
-    default=os.path.join(click.get_app_dir(__name__), "tasks.db"),
-    show_default=True,
-    help="Location of database.",
-)
 @click.confirmation_option(prompt="Are you sure you want to purge all tasks?")
-def purge(db: str):
+@click.pass_context
+def purge(ctx: click.core.Context):
     """Purge all tasks from the database"""
     pass
 
 
 @db.command()
-@click.option(
-    "--db",
-    type=click.Path(dir_okay=False, writable=True),
-    default=os.path.join(click.get_app_dir(__name__), "tasks.db"),
-    show_default=True,
-    help="Location of database.",
-)
 @click.confirmation_option(prompt="Are you sure you want to drop the database?")
-def drop(db: str):
+@click.pass_context
+def drop(ctx: click.core.Context):
     """Drop the databse"""
     pass
 
 
 @db.command()
-@click.option(
-    "--db",
-    type=click.Path(dir_okay=False, writable=True),
-    default=os.path.join(click.get_app_dir(__name__), "tasks.db"),
-    show_default=True,
-    help="Location of database.",
-)
 @click.confirmation_option(prompt="Are you sure you want to move the database?")
 @click.argument(
     "dest_db",
     type=click.Path(dir_okay=False, writable=True),
     default=os.path.join(click.get_app_dir(__name__), "tasks.db"),
 )
-def move(db: str, dest_db: str):
+@click.pass_context
+def move(ctx: click.core.Context, dest_db: str):
     """Move tasks database to DEST_DB
 
     DEST_DB will be overwriten if it already exists.

--- a/tasks3/cli.py
+++ b/tasks3/cli.py
@@ -20,7 +20,6 @@ def main(ctx: click.core.Context, db: str):
     ctx.ensure_object(dict)
 
     ctx.obj["DB"] = db
-    print(type(ctx))
     return 0
 
 

--- a/tasks3/cli.py
+++ b/tasks3/cli.py
@@ -32,6 +32,49 @@ def task(ctx: click.core.Context):
 
 @task.command()
 @click.option(
+    "--id",
+    type=str,
+    help="Filter by id. "
+    "You can pass /partial-id/ to search for all tasks whose id contains partial-id.",
+)
+@click.option("-T", "--title", type=str, help="Search by Title")
+@click.option(
+    "-u",
+    "--urgency",
+    type=click.IntRange(min=0, max=4, clamp=True),
+    help="Filter by urgency.",
+)
+@click.option(
+    "-i",
+    "--importance",
+    type=click.IntRange(min=0, max=4, clamp=True),
+    help="Filter by importance.",
+)
+@click.option("-t", "--tags", multiple=True, help="Filter by tags.")
+@click.option(
+    "-a",
+    "--anchor_folder",
+    type=click.Path(exists=True, readable=False, file_okay=False, resolve_path=True),
+    help="Filter by anchored folder.",
+)
+@click.option("-d", "--description", type=str, help="Search in description.")
+@click.pass_context
+def search(
+    ctx: click.core.Context,
+    id: str,
+    title: str,
+    urgency: int,
+    importance: int,
+    tags: list,
+    anchor_folder: str,
+    description: str,
+):
+    """Search for tasks"""
+    pass
+
+
+@task.command()
+@click.option(
     "-f",
     "--format",
     type=click.Choice(["YAML"]),
@@ -106,7 +149,7 @@ def remove(ctx: click.core.Context, yes: bool, id: str):
 @click.option("-t", "--tags", multiple=True, default=[], help="Tags for the Task.")
 @click.option(
     "-a",
-    "--anchor_to_folder",
+    "--anchor_folder",
     type=click.Path(exists=True, readable=False, file_okay=False, resolve_path=True),
     help="Anchor the Task to a specified directory or file.",
 )
@@ -123,7 +166,7 @@ def add(
     urgency: int,
     importance: int,
     tags: tuple,
-    anchor_to_folder: str,
+    anchor_folder: str,
     description: str,
     yes: bool,
 ):

--- a/tasks3/cli.py
+++ b/tasks3/cli.py
@@ -159,5 +159,27 @@ def drop(db: str):
     pass
 
 
+@db.command()
+@click.confirmation_option(prompt="Are you sure you want to move the database?")
+@click.option(
+    "--db",
+    type=click.Path(dir_okay=False, writable=True),
+    default=os.path.join(click.get_app_dir(__name__), "tasks.db"),
+    show_default=True,
+    help="Location of database",
+)
+@click.argument(
+    "dest_db",
+    type=click.Path(dir_okay=False, writable=True),
+    default=os.path.join(click.get_app_dir(__name__), "tasks.db"),
+)
+def move(db: str, dest_db: str):
+    """Move tasks database to DEST_DB
+
+    DEST_DB will be overwriten if it already exists.
+    """
+    pass
+
+
 if __name__ == "__main__":
     sys.exit(main())  # pragma: no cover

--- a/tasks3/cli.py
+++ b/tasks3/cli.py
@@ -7,13 +7,13 @@ import click
 @click.group()
 @click.version_option()
 def main(args=None):
-    """tasks3 is a commandline tool to create and manage tasks and todo lists."""
+    """tasks3 is a commandline tool to create and manage tasks and todo lists"""
     return 0
 
 
 @main.group()
 def task():
-    """Manage a task."""
+    """Manage a task"""
     pass
 
 
@@ -28,7 +28,7 @@ def task():
 )
 @click.argument("id", type=str)
 def show(format: str, id: str):
-    """Print the Task in the specified FORMAT.
+    """Show the task in the specified FORMAT
 
     ID is the id of the Task to be printed.
     """
@@ -109,8 +109,7 @@ def add(
     description: str,
     yes: bool,
 ):
-    """Add a new task.
-    """
+    """Add a new task"""
     pass
 
 
@@ -126,10 +125,10 @@ def db():
     type=click.Path(dir_okay=False, writable=True),
     default=os.path.join(click.get_app_dir(__name__), "tasks.db"),
     show_default=True,
-    help="Location of database",
+    help="Location of database.",
 )
 def init(db: str):
-    """Initialize and setup the database at db."""
+    """Initialize and setup the database"""
     pass
 
 
@@ -139,10 +138,11 @@ def init(db: str):
     type=click.Path(dir_okay=False, writable=True),
     default=os.path.join(click.get_app_dir(__name__), "tasks.db"),
     show_default=True,
-    help="Location of database",
+    help="Location of database.",
 )
 @click.confirmation_option(prompt="Are you sure you want to purge all tasks?")
 def purge(db: str):
+    """Purge all tasks from the database"""
     pass
 
 
@@ -152,10 +152,11 @@ def purge(db: str):
     type=click.Path(dir_okay=False, writable=True),
     default=os.path.join(click.get_app_dir(__name__), "tasks.db"),
     show_default=True,
-    help="Location of database",
+    help="Location of database.",
 )
 @click.confirmation_option(prompt="Are you sure you want to drop the database?")
 def drop(db: str):
+    """Drop the databse"""
     pass
 
 
@@ -165,7 +166,7 @@ def drop(db: str):
     type=click.Path(dir_okay=False, writable=True),
     default=os.path.join(click.get_app_dir(__name__), "tasks.db"),
     show_default=True,
-    help="Location of database",
+    help="Location of database.",
 )
 @click.confirmation_option(prompt="Are you sure you want to move the database?")
 @click.argument(

--- a/tasks3/cli.py
+++ b/tasks3/cli.py
@@ -37,10 +37,7 @@ def show(format: str, id: str):
 
 @task.command()
 @click.option(
-    "-y/-n",
-    "--yes/--no",
-    default=False,
-    help="Overwrite task data without confirmation?",
+    "--yes", default=False, help="Overwrite task data without confirmation?",
 )
 @click.argument("id", type=str)
 def edit(yes: bool, id: str):
@@ -53,7 +50,7 @@ def edit(yes: bool, id: str):
 
 @task.command()
 @click.option(
-    "-y/-n", "--yes/--no", default=False, help="Delete task without confirmation?"
+    "--yes", default=False, help="Delete task without confirmation?",
 )
 @click.argument("id", type=str)
 def remove(yes: bool, id: str):
@@ -101,7 +98,7 @@ def remove(yes: bool, id: str):
     "-d", "--description", default="", help="A short description of the Task."
 )
 @click.option(
-    "-y/-n", "--yes/--no", default=False, help="Create task without confirmation?"
+    "--yes", default=False, help="Create task without confirmation?",
 )
 def add(
     title: str,

--- a/tasks3/cli.py
+++ b/tasks3/cli.py
@@ -1,5 +1,6 @@
 """Console script for tasks3."""
 import sys
+import os
 import click
 
 
@@ -107,6 +108,48 @@ def add(
 ):
     """Add a new task.
     """
+    pass
+
+
+@main.group()
+def db():
+    """Manage tasks3's database"""
+    pass
+
+
+@db.command()
+@click.argument(
+    "db",
+    type=click.Path(dir_okay=False, writable=True),
+    default=os.path.join(click.get_app_dir(__name__), "tasks.db"),
+)
+def init(db: str):
+    """Initialize and setup the database at db.
+
+    If db is not provide a database at system's default app directory is used.
+    """
+    pass
+
+
+@db.command()
+@click.confirmation_option(prompt="Are you sure you want to purge all tasks?")
+@click.argument(
+    "db",
+    type=click.Path(dir_okay=False, writable=True),
+    default=os.path.join(click.get_app_dir(__name__), "tasks.db"),
+)
+def purge(db: str):
+    pass
+
+
+@db.command()
+@click.confirmation_option(prompt="Are you sure you want to drop the database?")
+@click.argument(
+    "db",
+    type=click.Path(dir_okay=False, writable=True),
+    default=os.path.join(click.get_app_dir(__name__), "tasks.db"),
+)
+def drop(db: str):
     pass
 
 

--- a/tasks3/cli.py
+++ b/tasks3/cli.py
@@ -26,7 +26,7 @@ def task():
     show_default=True,
 )
 @click.argument("id", type=str)
-def show(format, id):
+def show(format: str, id: str):
     """Print the Task in the specified FORMAT.
 
     ID is the id of the Task to be printed.
@@ -42,7 +42,7 @@ def show(format, id):
     help="Overwrite task data without confirmation?",
 )
 @click.argument("id", type=str)
-def edit(yes, id):
+def edit(yes: bool, id: str):
     """Edit a Task
 
     ID is the id of the Task to be edited.
@@ -55,7 +55,7 @@ def edit(yes, id):
     "-y/-n", "--yes/--no", default=False, help="Delete task without confirmation?"
 )
 @click.argument("id", type=str)
-def remove(yes, id):
+def remove(yes: bool, id: str):
     """Remove a Task
 
     ID is the id of the Task to be removed.
@@ -103,7 +103,7 @@ def remove(yes, id):
     "-y/-n", "--yes/--no", default=False, help="Create task without confirmation?"
 )
 def add(
-    title: str, urgency: int, importance: int, tags, anchor_to_folder, description, yes
+        title: str, urgency: int, importance: int, tags: tuple, anchor_to_folder: str, description: str, yes: bool
 ):
     """Add a new task.
     """

--- a/tasks3/cli.py
+++ b/tasks3/cli.py
@@ -5,7 +5,6 @@ import click
 
 
 @click.group()
-@click.version_option()
 @click.option(
     "--db",
     type=click.Path(dir_okay=False, writable=True),
@@ -13,6 +12,7 @@ import click
     show_default=True,
     help="Location of tasks database.",
 )
+@click.version_option()
 @click.pass_context
 def main(ctx: click.core.Context, db: str):
     """tasks3 is a commandline tool to create and manage tasks and todo lists"""

--- a/tasks3/cli.py
+++ b/tasks3/cli.py
@@ -3,7 +3,11 @@ import sys
 import os
 import click
 
+from pkg_resources import iter_entry_points
+from click_plugins import with_plugins
 
+
+@with_plugins(iter_entry_points("click_command_tree"))
 @click.group()
 @click.option(
     "--db",

--- a/tasks3/cli.py
+++ b/tasks3/cli.py
@@ -1,15 +1,110 @@
 """Console script for tasks3."""
+import tasks3
 import sys
 import click
 
 
-@click.command()
+@click.group()
+@click.version_option()
 def main(args=None):
-    """Console script for tasks3."""
-    click.echo("Replace this message by putting your code into "
-               "tasks3.cli.main")
-    click.echo("See click documentation at https://click.palletsprojects.com/")
+    """tasks3 is a commandline tool to create and manage tasks and todo lists."""
     return 0
+
+
+@main.group()
+def task():
+    """Manage a task."""
+    pass
+
+
+@task.command()
+@click.option(
+    "-f",
+    "--format",
+    type=click.Choice(["YAML"]),
+    default="YAML",
+    help="Output format.",
+    show_default=True,
+)
+@click.argument("id", type=str)
+def show(format, id):
+    """Print the Task in the specified FORMAT.
+
+    ID is the id of the Task to be printed.
+    """
+    pass
+
+
+@task.command()
+@click.option(
+    "-y/-n",
+    "--yes/--no",
+    default=False,
+    help="Overwrite task data without confirmation?",
+)
+@click.argument("id", type=str)
+def edit(yes, id):
+    """Edit a Task
+
+    ID is the id of the Task to be edited.
+    """
+    pass
+
+
+@task.command()
+@click.option(
+    "-y/-n", "--yes/--no", default=False, help="Delete task without confirmation?"
+)
+@click.argument("id", type=str)
+def remove(yes, id):
+    """Remove a Task
+
+    ID is the id of the Task to be removed.
+    """
+    pass
+
+
+@task.command()
+@click.option(
+    "-T", "--title", default="Give a Title to this Task.", help="Title of the Task."
+)
+@click.option(
+    "-u",
+    "--urgency",
+    type=click.IntRange(min=0, max=4, clamp=True),
+    default=2,
+    is_flag=True,
+    flag_value=4,
+    help="Level of urgency of the Task. Higher the value (max of 4) greater the urgency. Defaults to 2 when absent and 4 when present.",
+)
+@click.option(
+    "-i",
+    "--importance",
+    type=click.IntRange(min=0, max=4, clamp=True),
+    default=2,
+    is_flag=True,
+    flag_value=4,
+    help="Level of importance of the Task. Higher the value (max of 4) greater the importance. Defaults to 2 when absent and 4 when present.",
+)
+@click.option("-t", "--tags", multiple=True, default=[], help="Tags for the Task.")
+@click.option(
+    "-a",
+    "--anchor_to_folder",
+    type=click.Path(exists=True, readable=False, resolve_path=True),
+    help="Anchor the Task to a specified directory or file.",
+)
+@click.option(
+    "-d", "--description", default="", help="A short description of the Task."
+)
+@click.option(
+    "-y/-n", "--yes/--no", default=False, help="Create task without confirmation?"
+)
+def add(
+    title: str, urgency: int, importance: int, tags, anchor_to_folder, description, yes
+):
+    """Add a new task.
+    """
+    pass
 
 
 if __name__ == "__main__":

--- a/tasks3/cli.py
+++ b/tasks3/cli.py
@@ -94,7 +94,7 @@ def remove(yes: bool, id: str):
 @click.option(
     "-a",
     "--anchor_to_folder",
-    type=click.Path(exists=True, readable=False, resolve_path=True),
+    type=click.Path(exists=True, readable=False, file_okay=False, resolve_path=True),
     help="Anchor the Task to a specified directory or file.",
 )
 @click.option(
@@ -104,7 +104,13 @@ def remove(yes: bool, id: str):
     "-y/-n", "--yes/--no", default=False, help="Create task without confirmation?"
 )
 def add(
-        title: str, urgency: int, importance: int, tags: tuple, anchor_to_folder: str, description: str, yes: bool
+    title: str,
+    urgency: int,
+    importance: int,
+    tags: tuple,
+    anchor_to_folder: str,
+    description: str,
+    yes: bool,
 ):
     """Add a new task.
     """

--- a/tasks3/cli.py
+++ b/tasks3/cli.py
@@ -1,5 +1,4 @@
 """Console script for tasks3."""
-import tasks3
 import sys
 import click
 
@@ -75,7 +74,9 @@ def remove(yes, id):
     default=2,
     is_flag=True,
     flag_value=4,
-    help="Level of urgency of the Task. Higher the value (max of 4) greater the urgency. Defaults to 2 when absent and 4 when present.",
+    help="Level of urgency of the Task. "
+    "Higher the value (max of 4) greater the urgency. "
+    "Defaults to 2 when absent and 4 when present.",
 )
 @click.option(
     "-i",
@@ -84,7 +85,9 @@ def remove(yes, id):
     default=2,
     is_flag=True,
     flag_value=4,
-    help="Level of importance of the Task. Higher the value (max of 4) greater the importance. Defaults to 2 when absent and 4 when present.",
+    help="Level of importance of the Task. "
+    "Higher the value (max of 4) greater the importance. "
+    "Defaults to 2 when absent and 4 when present.",
 )
 @click.option("-t", "--tags", multiple=True, default=[], help="Tags for the Task.")
 @click.option(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+
+"""Tests for `tasks3` package."""
+
+import pytest
+
+from click.testing import CliRunner
+
+import tasks3 as package_tasks3
+from tasks3 import tasks3
+from tasks3 import cli
+
+
+def test_command_line_interface_help():
+    """Test the CLI"""
+    runner = CliRunner()
+    main_result = runner.invoke(cli.main)
+    assert main_result.exit_code == 0
+    assert package_tasks3.__doc__ in main_result.output
+
+
+def test_command_line_interface_version():
+    """Test the CLI (--version)"""
+    runner = CliRunner()
+    version_result = runner.invoke(cli.main, ["--version"])
+    assert version_result.exit_code == 0
+    assert package_tasks3.__version__ in version_result.output
+
+
+def test_command_line_interface_help():
+    """Test the CLI (--help)"""
+    runner = CliRunner()
+    help_result = runner.invoke(cli.main, ["--help"])
+    assert help_result.exit_code == 0
+    assert "--help     Show this message and exit." in help_result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,8 +7,7 @@ import pytest
 from click.testing import CliRunner
 
 import tasks3 as package_tasks3
-from tasks3 import tasks3
-from tasks3 import cli
+from tasks3 import tasks3, cli
 
 
 @pytest.fixture
@@ -17,21 +16,39 @@ def cli_runner():
 
 
 def test_command_line_interface_main(cli_runner):
-    """Test the CLI"""
+    """Test the CLI (tasks3)"""
     main_result = cli_runner.invoke(cli.main)
     assert main_result.exit_code == 0
     assert package_tasks3.__doc__ in main_result.output
 
 
 def test_command_line_interface_version(cli_runner):
-    """Test the CLI (--version)"""
+    """Test the CLI (tasks3 --version)"""
     version_result = cli_runner.invoke(cli.main, ["--version"])
     assert version_result.exit_code == 0
     assert package_tasks3.__version__ in version_result.output
 
 
-def test_command_line_interface_help(cli_runner):
-    """Test the CLI (--help)"""
+def test_command_line_interface_main_help(cli_runner):
+    """Test the CLI (tasks3 --help)"""
     help_result = cli_runner.invoke(cli.main, ["--help"])
     assert help_result.exit_code == 0
     assert "--help     Show this message and exit." in help_result.output
+
+
+def test_command_line_interface_task(cli_runner):
+    """Test the CLI (tasks3 task)"""
+    task_result = cli_runner.invoke(cli.main, ["task"])
+    assert task_result.exit_code == 0
+    assert cli.task.__doc__ in task_result.output
+    for command in cli.task.commands:
+        assert command in task_result.output
+
+
+def test_command_line_interface_task_help(cli_runner):
+    """Test the CLI (tasks3 task --help)"""
+    task_help_result = cli_runner.invoke(cli.main, ["task", "--help"])
+    assert task_help_result.exit_code == 0
+    assert cli.task.__doc__ in task_help_result.output
+    for command in cli.task.commands:
+        assert command in task_help_result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,25 +11,27 @@ from tasks3 import tasks3
 from tasks3 import cli
 
 
-def test_command_line_interface_help():
+@pytest.fixture
+def cli_runner():
+    return CliRunner()
+
+
+def test_command_line_interface_main(cli_runner):
     """Test the CLI"""
-    runner = CliRunner()
-    main_result = runner.invoke(cli.main)
+    main_result = cli_runner.invoke(cli.main)
     assert main_result.exit_code == 0
     assert package_tasks3.__doc__ in main_result.output
 
 
-def test_command_line_interface_version():
+def test_command_line_interface_version(cli_runner):
     """Test the CLI (--version)"""
-    runner = CliRunner()
-    version_result = runner.invoke(cli.main, ["--version"])
+    version_result = cli_runner.invoke(cli.main, ["--version"])
     assert version_result.exit_code == 0
     assert package_tasks3.__version__ in version_result.output
 
 
-def test_command_line_interface_help():
+def test_command_line_interface_help(cli_runner):
     """Test the CLI (--help)"""
-    runner = CliRunner()
-    help_result = runner.invoke(cli.main, ["--help"])
+    help_result = cli_runner.invoke(cli.main, ["--help"])
     assert help_result.exit_code == 0
     assert "--help     Show this message and exit." in help_result.output

--- a/tests/test_tasks3.py
+++ b/tests/test_tasks3.py
@@ -4,10 +4,7 @@
 
 import pytest
 
-from click.testing import CliRunner
-
-from tasks3 import tasks3
-from tasks3 import cli
+# from tasks3 import tasks3
 
 
 @pytest.fixture
@@ -24,14 +21,3 @@ def test_content(response):
     """Sample pytest test function with the pytest fixture as an argument."""
     # from bs4 import BeautifulSoup
     # assert 'GitHub' in BeautifulSoup(response.content).title.string
-
-
-def test_command_line_interface():
-    """Test the CLI."""
-    runner = CliRunner()
-    result = runner.invoke(cli.main)
-    assert result.exit_code == 0
-    assert 'tasks3.cli.main' in result.output
-    help_result = runner.invoke(cli.main, ['--help'])
-    assert help_result.exit_code == 0
-    assert '--help  Show this message and exit.' in help_result.output

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,11 @@ python =
     3.7: py37
     3.6: py36
 
+[flake8]
+max-line-length = 
+    # Match black's line length.
+    88
+
 [testenv:flake8]
 basepython = python
 deps = flake8


### PR DESCRIPTION
The CLI can be summarized as follows:

```
main - tasks3 is a commandline tool to create and manage tasks and todo lists
├── db - Manage tasks3's database
│   ├── drop - Drop the databse
│   ├── init - Initialize and setup the database
│   ├── move - Move tasks database to DEST_DB
│   └── purge - Purge all tasks from the database
├── task - Manage a task
│   ├── add - Add a new task
│   ├── edit - Edit a Task
│   ├── remove - Remove a Task
│   ├── search - Search for tasks
│   └── show - Show the task in the specified FORMAT
└── tree - show the command tree of the CLI

```