### PR TITLE
Start using requirements.txt

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,8 @@ include CONTRIBUTING.rst
 include HISTORY.rst
 include LICENSE
 include README.rst
+include setup.py
+include requirements.txt
 
 recursive-include tests *
 recursive-exclude * __pycache__

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Click==7.1.2
+click-command-tree==1.1.0
+click-plugins==1.1.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,7 +7,6 @@ tox==3.18.0
 coverage==5.2.1
 Sphinx==3.1.2
 twine==3.2.0
-Click==7.1.2
 pytest==5.4.3
 pytest-runner==5.2
 black==19.10b0

--- a/setup.py
+++ b/setup.py
@@ -10,11 +10,9 @@ with open("README.rst") as readme_file:
 with open("HISTORY.rst") as history_file:
     history = history_file.read()
 
-requirements = [
-    "Click>=7.0",
-    "click-plugins==1.1.1",
-    "click-command-tree==1.1.0",
-]
+with open("requirements.txt") as requirements_file:
+    requirements = requirements_file.read().splitlines()
+
 
 setup_requirements = [
     "pytest-runner",

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ deps =
     -r{toxinidir}/requirements_dev.txt
 ; If you want to make tox run the tests with the same versions, create a
 ; requirements.txt with the pinned versions and uncomment the following line:
-;     -r{toxinidir}/requirements.txt
+    -r{toxinidir}/requirements.txt
 commands =
     pip install -U pip
     pytest --basetemp={envtmpdir}


### PR DESCRIPTION
Using setup.py for requirements was becoming a hassle of managing two lists for deployment. Now instead we use requirements.txt for deployment and simply read it in from setup.py