### PR TITLE
add task

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,13 @@
 History
 =======
 
+0.3.0 (2022-05-02)
+------------------
+
+* Remove `tasks3 db init` cli command.
+* Implement `tasks3 task add` cli command.
+* Implement `task.yaml`, `task.short`, `task.one_line` methods to display task.
+
 0.2.8 (2022-05-01)
 ------------------
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,9 +5,9 @@ History
 0.3.0 (2022-05-02)
 ------------------
 
-* Remove `tasks3 db init` cli command.
-* Implement `tasks3 task add` cli command.
-* Implement `task.yaml`, `task.short`, `task.one_line` methods to display task.
+* Remove ``tasks3 db init`` cli command.
+* Implement ``tasks3 task add`` cli command.
+* Implement ``task.yaml``, ``task.short``, ``task.one_line`` methods to display task.
 
 0.2.8 (2022-05-01)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -30,6 +30,26 @@ A commandline tool to create and manage tasks and todos.
 Features
 --------
 
+* Easily create tasks from the commandline and deledate them to folders.
+
+.. code-block:: bash
+        :caption: Create a task in a specific folder with default settings.
+
+        tasks3 task add --title "Think of a cool name" --folder "~/Documents/story" --yes
+        Added Task:
+        [e1c100] Think of a cool name (⏰⏰    ) (🚨🚨  )
+          [path: ~/Documents/story]
+
+.. code-block:: bash
+        :caption: Create a task in a current folder with custom settings and description.
+
+        tasks3 task add --title "Try new model" --urgency 4 --importance 3 --description "Try:\n - model with 3 layers.\n - model with 4 layers." --yes
+        Added Task:
+        [a0a5f4] Try new model (⏰⏰⏰⏰) (🚨🚨🚨 )
+            Try:
+             - model with 3 layers.
+             - model with 4 layers.
+
 * TODO
 
 Credits

--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,9 @@ Features
 .. code-block:: bash
         :caption: Create a task in a specific folder with default settings.
 
-        tasks3 task add --title "Think of a cool name" --folder "~/Documents/story" --yes
+        tasks3 task add --title "Think of a cool name" \
+            --folder "~/Documents/story" \
+            --yes
         Added Task:
         [e1c100] Think of a cool name (⏰⏰    ) (🚨🚨  )
           [path: ~/Documents/story]
@@ -43,7 +45,10 @@ Features
 .. code-block:: bash
         :caption: Create a task in a current folder with custom settings and description.
 
-        tasks3 task add --title "Try new model" --urgency 4 --importance 3 --description "Try:\n - model with 3 layers.\n - model with 4 layers." --yes
+        tasks3 task add --title "Try new model" \
+            --urgency 4 --importance 3 \
+            --description "Try:\n - model with 3 layers.\n - model with 4 layers." \
+            --yes
         Added Task:
         [a0a5f4] Try new model (⏰⏰⏰⏰) (🚨🚨🚨 )
             Try:

--- a/tasks3/cli.py
+++ b/tasks3/cli.py
@@ -58,10 +58,10 @@ def task(ctx: click.core.Context):
 )
 @click.option("-t", "--tags", multiple=True, help="Filter by tags.")
 @click.option(
-    "-a",
-    "--anchor_folder",
+    "-f",
+    "--folder",
     type=click.Path(exists=True, readable=False, file_okay=False, resolve_path=True),
-    help="Filter by anchored folder.",
+    help="Filter by delegated folder.",
 )
 @click.option("-d", "--description", type=str, help="Search in description.")
 @click.pass_context
@@ -72,7 +72,7 @@ def search(
     urgency: int,
     importance: int,
     tags: list,
-    anchor_folder: str,
+    folder: str,
     description: str,
 ):
     """Search for tasks"""
@@ -158,10 +158,10 @@ def remove(ctx: click.core.Context, yes: bool, id: str):
 )
 @click.option("-t", "--tags", multiple=True, default=[], help="Tags for the Task.")
 @click.option(
-    "-a",
-    "--anchor_folder",
+    "-f",
+    "--folder",
     type=click.Path(exists=True, readable=False, file_okay=False, resolve_path=True),
-    help="Anchor the Task to a specified directory or file.",
+    help="Delegate Task to a specified directory or file.",
 )
 @click.option(
     "-d", "--description", default="", help="A short description of the Task."
@@ -178,7 +178,7 @@ def add(
     urgency: int,
     importance: int,
     tags: tuple,
-    anchor_folder: str,
+    folder: str,
     description: str,
     yes: bool,
 ):

--- a/tasks3/cli.py
+++ b/tasks3/cli.py
@@ -71,7 +71,7 @@ def task(ctx: click.core.Context):
 @click.option(
     "-f",
     "--folder",
-    type=click.Path(exists=True, readable=False, file_okay=False, resolve_path=True),
+    type=click.Path(readable=False, resolve_path=True, path_type=Path),
     help="Filter by delegated folder.",
 )
 @click.option("-d", "--description", type=str, help="Search in description.")
@@ -99,7 +99,7 @@ def search(
     help="Output format.",
     show_default=True,
 )
-@click.argument("id", type=str)
+@click.argument("id", type=str, required=False)
 @click.pass_context
 def show(ctx: click.core.Context, format: str, id: str):
     """Show the task in the specified FORMAT
@@ -165,7 +165,7 @@ def remove(ctx: click.core.Context, yes: bool, id: str):
 @click.option(
     "-f",
     "--folder",
-    type=click.Path(exists=True, readable=False, resolve_path=True),
+    type=click.Path(readable=False, resolve_path=True, path_type=Path),
     default=Path.cwd(),
     help="Delegate Task to a specified directory or file.  [default: current working directory]",
 )

--- a/tasks3/cli.py
+++ b/tasks3/cli.py
@@ -188,7 +188,7 @@ def add(
     urgency: int,
     importance: int,
     tags: Iterable[str],
-    folder: str,
+    folder: Path,
     description: Optional[str],
     yes: bool,
 ):
@@ -200,7 +200,7 @@ def add(
         urgency=urgency,
         importance=importance,
         tags=tags,
-        folder=folder,
+        folder=str(folder),
         description=description,
     )
     if not yes:

--- a/tasks3/cli.py
+++ b/tasks3/cli.py
@@ -218,13 +218,6 @@ def db(ctx: click.core.Context):
 
 
 @db.command()
-@click.pass_context
-def init(ctx: click.core.Context):
-    """Initialize and setup the database"""
-    pass
-
-
-@db.command()
 @click.confirmation_option(prompt="Are you sure you want to purge all tasks?")
 @click.pass_context
 def purge(ctx: click.core.Context):

--- a/tasks3/cli.py
+++ b/tasks3/cli.py
@@ -167,7 +167,10 @@ def remove(ctx: click.core.Context, yes: bool, id: str):
     "--folder",
     type=click.Path(readable=False, resolve_path=True, path_type=Path),
     default=Path.cwd(),
-    help="Delegate Task to a specified directory or file.  [default: current working directory]",
+    help=(
+        "Delegate Task to a specified directory or file.  "
+        "[default: current working directory]"
+    ),
 )
 @click.option(
     "-d", "--description", default="", help="A short description of the Task."
@@ -206,7 +209,7 @@ def add(
             abort=True,
             default=True,
         )
-    task_id = tasks3.add(task, db_engine=engine)
+    tasks3.add(task, db_engine=engine)
     click.echo(f"Added Task:\n{task.short()}")
 
 

--- a/tasks3/db/extension.py
+++ b/tasks3/db/extension.py
@@ -9,12 +9,12 @@ from sqlalchemy.orm import Session
 
 
 @contextmanager
-def session_scope(bind: Engine) -> Generator[Session, Engine, None]:
+def session_scope(bind: Engine, *args, **kwargs) -> Generator[Session, Engine, None]:
     """Provide a transactional scope around a series of database operations.
 
     src: https://docs.sqlalchemy.org/en/13/orm/session_basics.html
     """
-    session = Session(bind=bind)
+    session = Session(bind=bind, expire_on_commit=False, *args, **kwargs)
     try:
         yield session
         session.commit()

--- a/tasks3/db/models.py
+++ b/tasks3/db/models.py
@@ -89,12 +89,12 @@ class Task(Base):
             return self.folder
 
     def one_line(self) -> str:
-        """One line representation of the task"""
+        """One line Human-friendly representation of the task"""
         rep = "[      ] "
         if self.id is not None and len(self.id) == UUID_LENGTH:
             rep = f"[{self.id}] "
         rep += f"{BOLD}{self.title}{END}"
-        if self.folder is not None:
+        if self.relative_folder is not None and self.relative_folder != ".":
             rep += f" [path: {UNDERLINE}{self.relative_folder}{END}]"
         return rep
 
@@ -106,11 +106,13 @@ class Task(Base):
         urgent = ("⏰" * self.urgency) + ("  " * (4 - self.urgency))
         important = ("🚨" * self.importance) + (" " * (4 - self.importance))
         rep += f"{BOLD}{self.title}{END} ({urgent}) ({important})"
-        if self.folder is not None:
+        if self.relative_folder is not None and self.relative_folder != ".":
             rep += "\n  " + f"[path: {UNDERLINE}{self.relative_folder}{END}]"
         if len(self.tags) > 0:
             tags = [f"({tag})" for tag in self.tags]
             rep += "\n  " + " ".join(tags)
+        if self.description is not None and len(self.description) > 0:
+            rep += "\n    " + self.description.replace("\n", "\n    ")
         return rep
 
     def yaml(self) -> str:

--- a/tasks3/db/models.py
+++ b/tasks3/db/models.py
@@ -71,5 +71,21 @@ class Task(Base):
             description=self.description,
         )
 
+    def yaml(self) -> str:
+        top = (
+            f"title: {self.title}\n"
+            f"urgency: {self.urgency}\n"
+            f"importance: {self.importance}"
+        )
+        tags = "tags: null"
+        if len(self.tags) > 0:
+            tags = "tags:\n  - " + "\n  - ".join(self.tags)
+        folder = f"folder: {'null' if self.folder is None else self.folder}"
+        yaml = f"{top}\n{tags}\n{folder}\n"
+        if self.description is not None and len(self.description) > 0:
+            description = self.description.replace("\n", "\n  ")
+            yaml += f"description: >-\n  {description}\n"
+        return yaml
+
     def __repr__(self) -> str:
         return f"<Task{self.to_dict().__repr__()}>"

--- a/tasks3/db/models.py
+++ b/tasks3/db/models.py
@@ -16,9 +16,9 @@ from sqlalchemy.ext.declarative import as_declarative, declared_attr
 
 UUID_LENGTH = 6
 
-BOLD = '\033[1m'
-UNDERLINE = '\033[4m'
-END = '\033[0m'
+BOLD = "\033[1m"
+UNDERLINE = "\033[4m"
+END = "\033[0m"
 
 
 @as_declarative()

--- a/tasks3/tasks3.py
+++ b/tasks3/tasks3.py
@@ -2,12 +2,23 @@
 
 import tasks3.db as db
 
+from functools import singledispatch
 from typing import List
+
+from tasks3.db import Task
+
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Query
 
 
-def add(
+@singledispatch
+def add(task) -> str:
+    """Add a task"""
+    raise NotImplementedError(f"No handler for type {type(task)}")
+
+
+@add.register(str)
+def _(
     title: str,
     urgency: int,
     importance: int,
@@ -34,6 +45,19 @@ def add(
         folder=anchor_folder,
         description=description,
     )
+    return add(task, db_engine)
+
+
+@add.register(Task)
+def _(
+    task: Task,
+    db_engine: Engine,
+) -> str:
+    """Add a task
+
+    :param task: Task to add.
+    :param db_engine: Engine for the tasks database.
+    """
     with db.session_scope(db_engine) as session:
         session.add(task)
         session.flush()

--- a/tasks3/tasks3.py
+++ b/tasks3/tasks3.py
@@ -12,13 +12,7 @@ from sqlalchemy.orm import Query
 
 
 @singledispatch
-def add(task) -> str:
-    """Add a task"""
-    raise NotImplementedError(f"No handler for type {type(task)}")
-
-
-@add.register(str)
-def _(
+def add(
     title: str,
     urgency: int,
     importance: int,

--- a/tasks3/tasks3.py
+++ b/tasks3/tasks3.py
@@ -1,11 +1,9 @@
 """Main module."""
 
-import tasks3.db as db
-
 from functools import singledispatch
 from typing import List
 
-from tasks3.db import Task
+from tasks3.db import Task, session_scope
 
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Query
@@ -31,7 +29,7 @@ def add(
     :param description: Description of the task.
     :param db_engine: Engine for the tasks database.
     """
-    task = db.Task(
+    task = Task(
         title=title,
         urgency=urgency,
         importance=importance,
@@ -52,7 +50,7 @@ def _(
     :param task: Task to add.
     :param db_engine: Engine for the tasks database.
     """
-    with db.session_scope(db_engine) as session:
+    with session_scope(db_engine) as session:
         session.add(task)
         session.flush()
         return task.id
@@ -79,8 +77,8 @@ def edit(
     :param folder: Delegate this task to a particular directory or file.
     :param description: Description of the task.
     """
-    with db.session_scope(db_engine) as session:
-        task: Task = Query(db.Task, session).filter_by(id=id).one()
+    with session_scope(db_engine) as session:
+        task: Task = Query(Task, session).filter_by(id=id).one()
         if title:
             task.title = title
         if urgency:
@@ -96,14 +94,13 @@ def edit(
         session.add(task)
 
 
-def remove(id: str, db_engine: Engine) -> db.Task:
+def remove(id: str, db_engine: Engine) -> Task:
     """Remove a Task
 
     :param id: ID of the task to remove.
     :param db_engine: Engine for the tasks database.
     """
-    task: db.Task
-    with db.session_scope(db_engine) as session:
-        task = Query(db.Task, session).filter_by(id=id).one()
+    with session_scope(db_engine) as session:
+        task: Task = Query(Task, session).filter_by(id=id).one()
         session.delete(task)
     return task

--- a/tasks3/tasks3.py
+++ b/tasks3/tasks3.py
@@ -89,8 +89,8 @@ def edit(
             task.importance = importance
         if tags:
             task.tags = tags
-        if anchor_folder:
-            task.folder = anchor_folder
+        if folder:
+            task.folder = folder
         if description:
             task.description = description
         session.add(task)

--- a/tasks3/tasks3.py
+++ b/tasks3/tasks3.py
@@ -17,7 +17,7 @@ def add(
     urgency: int,
     importance: int,
     tags: List[str],
-    anchor_folder: str,
+    folder: str,
     description: str,
     db_engine: Engine,
 ) -> str:
@@ -27,7 +27,7 @@ def add(
     :param urgency: Urgency level[0-4] for the new task.
     :param importance: Importance level[0-4] for the new task.
     :param tags: Set of tags to apply to the new task.
-    :param anchor_folder: Anchor this task to a particular directory or file.
+    :param folder: Delegate this task to a particular directory or file.
     :param description: Description of the task.
     :param db_engine: Engine for the tasks database.
     """
@@ -36,7 +36,7 @@ def add(
         urgency=urgency,
         importance=importance,
         tags=tags,
-        folder=anchor_folder,
+        folder=folder,
         description=description,
     )
     return add(task, db_engine)
@@ -65,7 +65,7 @@ def edit(
     urgency: int = None,
     importance: int = None,
     tags: List[str] = None,
-    anchor_folder: str = None,
+    folder: str = None,
     description: str = None,
 ):
     """Edit a task
@@ -76,12 +76,11 @@ def edit(
     :param urgency: Update urgency level[0-4] of the task.
     :param importance: Update importance level[0-4] of the task.
     :param tags: Set of tags to apply to the new task.
-    :param anchor_folder: Anchor this task to a particular directory or file.
+    :param folder: Delegate this task to a particular directory or file.
     :param description: Description of the task.
     """
-    task: db.Task
     with db.session_scope(db_engine) as session:
-        task = Query(db.Task, session).filter_by(id=id).one()
+        task: Task = Query(db.Task, session).filter_by(id=id).one()
         if title:
             task.title = title
         if urgency:

--- a/tests/test_db_task.py
+++ b/tests/test_db_task.py
@@ -30,7 +30,12 @@ def tags(request) -> Set[str]:
 
 
 def test_task_create(title: str, urgency: int, importance: int, tags: Set[str]):
-    task = Task(title=title, urgency=urgency, importance=importance, tags=tags,)
+    task = Task(
+        title=title,
+        urgency=urgency,
+        importance=importance,
+        tags=tags,
+    )
     assert task.title == title
     assert task.urgency == urgency
     assert task.importance == importance

--- a/tests/test_tasks3_tasks3.py
+++ b/tests/test_tasks3_tasks3.py
@@ -100,7 +100,7 @@ def test_task_add2(
         urgency=urgency,
         importance=importance,
         tags=tags,
-        anchor_folder=anchor_path,
+        folder=anchor_path,
         description=description,
         db_engine=db_engine,
     )
@@ -140,7 +140,7 @@ def test_task_edit1(tmp_path: Path, db_backend: str):
         urgency=urgency,
         importance=importance,
         tags=tags,
-        anchor_folder=anchor_path,
+        folder=anchor_path,
         description=description,
     )
     with db.session_scope(db_engine) as session:
@@ -168,7 +168,7 @@ def test_task_edit2(tmp_path: Path, db_backend: str):
         urgency=2,
         importance=2,
         tags=["old-tags"],
-        anchor_folder=".",
+        folder=".",
         description="Old description",
         db_engine=db_engine,
     )
@@ -179,7 +179,7 @@ def test_task_edit2(tmp_path: Path, db_backend: str):
         urgency=urgency,
         importance=importance,
         tags=tags,
-        anchor_folder=anchor_path,
+        folder=anchor_path,
         description=description,
     )
     with db.session_scope(db_engine) as session:
@@ -243,7 +243,7 @@ def test_task_remove2(
         urgency=urgency,
         importance=importance,
         tags=tags,
-        anchor_folder=anchor_path,
+        folder=anchor_path,
         description=description,
         db_engine=db_engine,
     )

--- a/tests/test_tasks3_tasks3.py
+++ b/tests/test_tasks3_tasks3.py
@@ -54,7 +54,37 @@ def get_db_engine(tmp_path: Path, backend: str) -> str:
     return engine
 
 
-def test_task_add(
+def test_task_add1(
+    tmp_path: Path,
+    title,
+    urgency,
+    importance,
+    tags,
+    anchor_path,
+    description,
+    db_backend: str,
+):
+    db_engine = get_db_engine(tmp_path, db_backend)
+    task = db.Task(
+        title=title,
+        urgency=urgency,
+        importance=importance,
+        tags=tags,
+        folder=anchor_path,
+        description=description,
+    )
+    id = tasks3.add(task, db_engine)
+    with db.session_scope(db_engine) as session:
+        task: db.Task = session.query(db.Task).filter_by(id=id).one()
+        assert task.title == title
+        assert task.urgency == urgency
+        assert task.importance == importance
+        assert task.tags == tags
+        assert task.folder == anchor_path
+        assert task.description == description
+
+
+def test_task_add2(
     tmp_path: Path,
     title,
     urgency,
@@ -66,7 +96,7 @@ def test_task_add(
 ):
     db_engine = get_db_engine(tmp_path, db_backend)
     id = tasks3.add(
-        title=title,
+        title,
         urgency=urgency,
         importance=importance,
         tags=tags,
@@ -84,7 +114,46 @@ def test_task_add(
         assert task.description == description
 
 
-def test_task_edit(tmp_path: Path, db_backend: str):
+def test_task_edit1(tmp_path: Path, db_backend: str):
+    db_engine = get_db_engine(tmp_path, db_backend)
+    title, urgency, importance, tags, anchor_path, description = (
+        "New Title",
+        4,
+        4,
+        ["new-tags"],
+        "/tmp",
+        "New description.",
+    )
+    task = db.Task(
+        title="Old title",
+        urgency=2,
+        importance=2,
+        tags=["old-tags"],
+        folder=".",
+        description="Old description",
+    )
+    id = tasks3.add(task, db_engine)
+    tasks3.edit(
+        id=id,
+        db_engine=db_engine,
+        title=title,
+        urgency=urgency,
+        importance=importance,
+        tags=tags,
+        anchor_folder=anchor_path,
+        description=description,
+    )
+    with db.session_scope(db_engine) as session:
+        task: db.Task = session.query(db.Task).filter_by(id=id).one()
+        assert task.title == title
+        assert task.urgency == urgency
+        assert task.importance == importance
+        assert task.tags == tags
+        assert task.folder == anchor_path
+        assert task.description == description
+
+
+def test_task_edit2(tmp_path: Path, db_backend: str):
     db_engine = get_db_engine(tmp_path, db_backend)
     title, urgency, importance, tags, anchor_path, description = (
         "New Title",
@@ -95,7 +164,7 @@ def test_task_edit(tmp_path: Path, db_backend: str):
         "New description.",
     )
     id = tasks3.add(
-        title="Old title",
+        "Old title",
         urgency=2,
         importance=2,
         tags=["old-tags"],
@@ -123,7 +192,42 @@ def test_task_edit(tmp_path: Path, db_backend: str):
         assert task.description == description
 
 
-def test_task_remove(
+def test_task_remove1(
+    tmp_path: Path,
+    title,
+    urgency,
+    importance,
+    tags,
+    anchor_path,
+    description,
+    db_backend: str,
+):
+    db_engine = get_db_engine(tmp_path, db_backend)
+    temp_task = db.Task(
+        title=title,
+        urgency=urgency,
+        importance=importance,
+        tags=tags,
+        folder=anchor_path,
+        description=description,
+    )
+    id = tasks3.add(temp_task, db_engine)
+    with db.session_scope(db_engine) as session:
+        task: db.Task = session.query(db.Task).filter_by(id=id).one()
+        assert task is not None
+    task = tasks3.remove(id, db_engine)
+    assert task.title == title
+    assert task.urgency == urgency
+    assert task.importance == importance
+    assert task.tags == tags
+    assert task.folder == anchor_path
+    assert task.description == description
+    with db.session_scope(db_engine) as session:
+        task: db.Task = session.query(db.Task).filter_by(id=id).first()
+        assert task is None
+
+
+def test_task_remove2(
     tmp_path: Path,
     title,
     urgency,
@@ -135,7 +239,7 @@ def test_task_remove(
 ):
     db_engine = get_db_engine(tmp_path, db_backend)
     id = tasks3.add(
-        title=title,
+        title,
         urgency=urgency,
         importance=importance,
         tags=tags,

--- a/tests/test_tasks3_tasks3.py
+++ b/tests/test_tasks3_tasks3.py
@@ -24,22 +24,22 @@ def urgency(request) -> int:
     return request.param
 
 
-@pytest.fixture(params=[0, 4], ids=["Not Important", "Very Important"])
+@pytest.fixture(params=[2])
 def importance(request) -> int:
     return request.param
 
 
-@pytest.fixture(params=[["pytest"]])
+@pytest.fixture(params=[[], ["pytest"]])
 def tags(request) -> List[str]:
     return request.param
 
 
-@pytest.fixture(params=[".", None])
+@pytest.fixture(params=[None, "/", "/foo/bar/baz"])
 def anchor_path(request) -> List[str]:
     return request.param
 
 
-@pytest.fixture(params=["Testing tasks3 interface."])
+@pytest.fixture(params=[None, "Testing tasks3 interface."])
 def description(request) -> List[str]:
     return request.param
 


### PR DESCRIPTION
- Add overrides for tasks3.add method
- Implement YAML pretty-printer for Tasks.
- Simplify singledispatch for tasks3.add
- Make tests cover edge cases.
- Refactor anchor_folder → folder
- Implement cli to add tasks.
- Improve one_line and short representation of Task.
- Fix typs anchor_folder → folder.
- Improve cli interface by relaxing constraints.
- Remove redundant cli
- Lint with black.
- Simplify code by using directly using imported values.
- Lint with flake8
- Update HISTORY and README
- Fix typing issue in cli.add
- Add documentation for creating tasks.
