### PR TITLE
Add core features: search + show

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,6 +10,7 @@ History
 * Implement the ``tasks3 task show`` cli endpoint.
 * Update docs.
 * Add Output format preference to config.
+* Make the cli interface easier to use (flatten the task command tree)
 
 0.3.3 (2022-05-02)
 ------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,15 @@
 History
 =======
 
+0.4.0 (2022-05-03)
+------------------
+
+* Add the ability to search for tasks.
+* Add json output format for tasks.
+* Implement the ``tasks3 task show`` cli endpoint.
+* Update docs.
+* Add Output format preference to config.
+
 0.3.3 (2022-05-02)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ Create a task in a specific folder with default settings.
 
 .. code-block:: bash
 
-        tasks3 task add --title "Think of a cool name" \
+        tasks3 add --title "Think of a cool name" \
             --folder "~/Documents/story" \
             --yes
         Added Task:
@@ -50,7 +50,7 @@ Create a task in a current folder with custom settings and description.
 
 .. code-block:: bash
 
-        tasks3 task add --title "Try new model" \
+        tasks3 add --title "Try new model" \
             --urgency 4 --importance 3 \
             --description "Try:\n - model with 3 layers.\n - model with 4 layers." \
             --yes
@@ -69,7 +69,7 @@ You can search for tasks with a specific importance value.
 
 .. code-block:: bash
 
-        tasks3 task search --importance 2
+        tasks3 search --importance 2
         [4a14d0] What is right here and now
         [f79155] Think of a cool name [path: /home/<user>/Documents/project]
         [2ce91b] See home [path: /home]
@@ -78,7 +78,7 @@ You can restrict search to a folder and its sub-directories.
 
 .. code-block:: bash
 
-        tasks3 task search --folder ~/Documents/project --output-format yaml
+        tasks3 search --folder ~/Documents/project --output-format yaml
         title: Think of a Cool name
         urgency: 2
         importance: 2
@@ -96,7 +96,7 @@ Show Tasks
 
 .. code-block:: bash
 
-        tasks3 task show
+        tasks3 show
         [a0a5f4] Try new model (⏰⏰⏰⏰) (🚨🚨🚨 )
             Try:
              model with 3 layers.
@@ -107,7 +107,7 @@ Show Tasks
 
 .. code-block:: bash
 
-        tasks3 task show 1d8a9a
+        tasks3 show 1d8a9a
         [1d8a9a] Give a Title to this Task. (⏰⏰    ) (🚨🚨🚨🚨)
           (Hello tasks3)
             Task with
@@ -116,7 +116,7 @@ Show Tasks
 
 .. code-block:: bash
 
-        tasks3 task show --output-format json 1d8a9a
+        tasks3 show --output-format json 1d8a9a
         {
           "id": "1d8a9a",
           "title": "Give a Title to this Task.",

--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,10 @@ A commandline tool to create and manage tasks and todos.
 Features
 --------
 
-* Easily create tasks from the commandline and delegate them to folders.
+Create Tasks
+============
+
+Easily create tasks from the commandline and delegate them to folders.
 
 Create a task in a specific folder with default settings.
 
@@ -57,7 +60,77 @@ Create a task in a current folder with custom settings and description.
              - model with 3 layers.
              - model with 4 layers.
 
-* TODO
+Search Tasks
+============
+
+You can search for tasks using various filters.
+
+You can search for tasks with a specific importance value.
+
+.. code-block:: bash
+
+        tasks3 task search --importance 2
+        [4a14d0] What is right here and now
+        [f79155] Think of a cool name [path: /home/<user>/Documents/project]
+        [2ce91b] See home [path: /home]
+
+You can restrict search to a folder and its sub-directories.
+
+.. code-block:: bash
+
+        tasks3 task search --folder ~/Documents/project --output-format yaml
+        title: Think of a Cool name
+        urgency: 2
+        importance: 2
+        tags: null
+        folder: /home/<user>/Documents/project
+
+You can also search for sub-strings in task title or description.
+It is also possible to restrict the search to tasks that have a specific set of tags.
+Run ``tasks3 search --help`` to get see a full list off options.
+
+Show Tasks
+==========
+
+* You can show all tasks under current directory.
+
+.. code-block:: bash
+
+        tasks3 task show
+        [a0a5f4] Try new model (⏰⏰⏰⏰) (🚨🚨🚨 )
+            Try:
+             model with 3 layers.
+             model with 4 layers.
+        [4a14d0] What is right here and now (⏰⏰    ) (🚨🚨  )
+
+* You can also show a particular task by specifying its id.
+
+.. code-block:: bash
+
+        tasks3 task show 1d8a9a
+        [1d8a9a] Give a Title to this Task. (⏰⏰    ) (🚨🚨🚨🚨)
+          (Hello tasks3)
+            Task with
+            multi-line
+            desc
+
+.. code-block:: bash
+
+        tasks3 task show --output-format json 1d8a9a
+        {
+          "id": "1d8a9a",
+          "title": "Give a Title to this Task.",
+          "urgency": 2,
+          "importance": 4,
+          "tags": [
+            "Hello tasks3"
+          ],
+          "folder": "/home/<user>/Documents/tasks3",
+          "description": "Task with \nmulti-line \ndesc"
+        }
+
+* TODO: Edit existing tasks.
+* TODO: Delete tasks.
 
 Credits
 -------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
 Click==8.1.3
-click-command-tree==1.1.0
-click-plugins==1.1.1
 ruamel.yaml==0.17.21
 SQLAlchemy==1.4.36

--- a/tasks3/__init__.py
+++ b/tasks3/__init__.py
@@ -4,4 +4,4 @@ __author__ = """Harsh Parekh"""
 __email__ = "harsh_parekh@outlook.com"
 __version__ = "0.3.3"
 
-from tasks3.tasks3 import add, edit, remove  # noqa: F401
+from tasks3.tasks3 import add, edit, remove, search  # noqa: F401

--- a/tasks3/cli.py
+++ b/tasks3/cli.py
@@ -8,7 +8,7 @@ import click
 import sqlalchemy
 
 from pathlib import Path
-from typing import Optional, Iterable, List
+from typing import Callable, Optional, Iterable, List
 
 from tasks3.config import config, OutputFormat
 from tasks3.db import Task
@@ -108,14 +108,7 @@ def search(
         description=description,
     )
     output_format = OutputFormat(output_format)
-    if output_format == OutputFormat.oneline:
-        fmt = Task.one_line
-    elif output_format == OutputFormat.short:
-        fmt = Task.short
-    elif output_format == OutputFormat.yaml:
-        fmt = lambda self: Task.yaml(self=self) + "\n"
-    elif output_format == OutputFormat.json:
-        fmt = Task.json
+    fmt = __fmt(output_format)
     for task in results:
         click.echo(fmt(self=task))
 
@@ -280,6 +273,23 @@ def move(ctx: click.core.Context, dest_db: str):
     DEST_DB will be overwriten if it already exists.
     """
     pass
+
+
+def __fmt(format: OutputFormat) -> Callable[[Task], str]:
+    """
+    Return a function that formats a Task object according to the specified format.
+
+    :param format: The format to use.
+    """
+    if format == OutputFormat.oneline:
+        fmt = Task.one_line
+    elif format == OutputFormat.short:
+        fmt = Task.short
+    elif format == OutputFormat.yaml:
+        fmt = lambda self: Task.yaml(self=self) + "\n"
+    elif format == OutputFormat.json:
+        fmt = Task.json
+    return fmt
 
 
 if __name__ == "__main__":

--- a/tasks3/cli.py
+++ b/tasks3/cli.py
@@ -13,11 +13,7 @@ from typing import Callable, Optional, Iterable, List
 from tasks3.config import config, OutputFormat
 from tasks3.db import Task
 
-from pkg_resources import iter_entry_points
-from click_plugins import with_plugins
 
-
-@with_plugins(iter_entry_points("click_command_tree"))
 @click.group()
 @click.option(
     "--db",
@@ -40,14 +36,7 @@ def main(ctx: click.core.Context, db: Path):
     return 0
 
 
-@main.group()
-@click.pass_context
-def task(ctx: click.core.Context):
-    """Manage a task"""
-    pass
-
-
-@task.command()
+@main.command()
 @click.option(
     "--id",
     type=str,
@@ -115,7 +104,7 @@ def search(
         click.echo(fmt(self=task))
 
 
-@task.command()
+@main.command()
 @click.option(
     "-o",
     "--output-format",
@@ -143,7 +132,7 @@ def show(ctx: click.core.Context, output_format: str, id: str):
     pass
 
 
-@task.command()
+@main.command()
 @click.option(
     "--yes",
     default=False,
@@ -159,7 +148,7 @@ def edit(ctx: click.core.Context, yes: bool, id: str):
     pass
 
 
-@task.command()
+@main.command()
 @click.option(
     "--yes",
     default=False,
@@ -175,7 +164,7 @@ def remove(ctx: click.core.Context, yes: bool, id: str):
     pass
 
 
-@task.command()
+@main.command()
 @click.option(
     "-T", "--title", default="Give a Title to this Task.", help="Title of the Task."
 )

--- a/tasks3/cli.py
+++ b/tasks3/cli.py
@@ -117,20 +117,29 @@ def search(
 
 @task.command()
 @click.option(
-    "-f",
-    "--format",
-    type=click.Choice(["YAML"]),
-    default="YAML",
+    "-o",
+    "--output-format",
+    type=click.Choice([fmt.value for fmt in OutputFormat]),
+    default=config.show_output_format,
     help="Output format.",
     show_default=True,
 )
 @click.argument("id", type=str, required=False)
 @click.pass_context
-def show(ctx: click.core.Context, format: str, id: str):
+def show(ctx: click.core.Context, output_format: str, id: str):
     """Show the task in the specified FORMAT
 
-    ID is the id of the Task to be printed.
+    ID is the id of the Task to be printed;
+    if not specified, all tasks in current directory are printed.
     """
+    engine = ctx.obj["engine"]
+    fmt = __fmt(OutputFormat(output_format))
+    if id is None:
+        tasks = tasks3.search(db_engine=engine, folder=str(Path.cwd()))
+    else:
+        tasks = tasks3.search(db_engine=engine, id=id)[:1]
+    for task in tasks:
+        click.echo(fmt(self=task))
     pass
 
 

--- a/tasks3/cli.py
+++ b/tasks3/cli.py
@@ -71,7 +71,7 @@ def task(ctx: click.core.Context):
 @click.option(
     "-f",
     "--folder",
-    type=click.Path(readable=False, resolve_path=True, path_type=Path),
+    type=click.Path(readable=False, path_type=Path),
     help="Filter by delegated folder.",
 )
 @click.option("-d", "--description", type=str, help="Search in description.")
@@ -97,6 +97,8 @@ def search(
 ):
     """Search for tasks"""
     engine = ctx.obj["engine"]
+    if folder:
+        folder = str(folder.expanduser().resolve())
     results: List[Task] = tasks3.search(
         db_engine=engine,
         id=id,
@@ -188,7 +190,7 @@ def remove(ctx: click.core.Context, yes: bool, id: str):
 @click.option(
     "-f",
     "--folder",
-    type=click.Path(readable=False, resolve_path=True, path_type=Path),
+    type=click.Path(readable=False, path_type=Path),
     default=Path.cwd(),
     help=(
         "Delegate Task to a specified directory or file.  "
@@ -223,7 +225,7 @@ def add(
         urgency=urgency,
         importance=importance,
         tags=tags,
-        folder=str(folder),
+        folder=str(folder.expanduser().resolve()),
         description=description,
     )
     if not yes:

--- a/tasks3/cli.py
+++ b/tasks3/cli.py
@@ -79,7 +79,7 @@ def task(ctx: click.core.Context):
     "-o",
     "--output-format",
     type=click.Choice([fmt.value for fmt in OutputFormat]),
-    default=config.preferred_format,
+    default=config.search_output_format,
     show_default=True,
     help="Output format.",
 )

--- a/tasks3/cli.py
+++ b/tasks3/cli.py
@@ -297,7 +297,11 @@ def __fmt(format: OutputFormat) -> Callable[[Task], str]:
     elif format == OutputFormat.short:
         fmt = Task.short
     elif format == OutputFormat.yaml:
-        fmt = lambda self: Task.yaml(self=self) + "\n"
+
+        def _fmt(self):
+            return Task.yaml(self=self) + "\n"
+
+        fmt = _fmt
     elif format == OutputFormat.json:
         fmt = Task.json
     return fmt

--- a/tasks3/config.py
+++ b/tasks3/config.py
@@ -37,6 +37,7 @@ class Config:
     db: str = str(DEFAULT_DATA_FOLDER_PATH / "tasks.db")
     backend: str = DBBackend.sqlite.value
     preferred_format: str = OutputFormat.short.value
+    show_output_format: str = OutputFormat.short.value
 
     @property
     def db_backend(self) -> DBBackend:

--- a/tasks3/config.py
+++ b/tasks3/config.py
@@ -23,10 +23,20 @@ class DBBackend(Enum):
     postgresql = "postgresql"
 
 
+class OutputFormat(Enum):
+    """Supported output formats"""
+
+    oneline = "oneline"
+    short = "short"
+    yaml = "yaml"
+    json = "json"
+
+
 @dataclass
 class Config:
     db: str = str(DEFAULT_DATA_FOLDER_PATH / "tasks.db")
     backend: str = DBBackend.sqlite.value
+    preferred_format: str = OutputFormat.short.value
 
     @property
     def db_backend(self) -> DBBackend:

--- a/tasks3/config.py
+++ b/tasks3/config.py
@@ -36,7 +36,7 @@ class OutputFormat(Enum):
 class Config:
     db: str = str(DEFAULT_DATA_FOLDER_PATH / "tasks.db")
     backend: str = DBBackend.sqlite.value
-    preferred_format: str = OutputFormat.short.value
+    search_output_format: str = OutputFormat.oneline.value
     show_output_format: str = OutputFormat.short.value
 
     @property

--- a/tasks3/db/models.py
+++ b/tasks3/db/models.py
@@ -116,6 +116,7 @@ class Task(Base):
         return rep
 
     def yaml(self) -> str:
+        """YAML representation of the task"""
         top = (
             f"title: {self.title}\n"
             f"urgency: {self.urgency}\n"

--- a/tasks3/db/models.py
+++ b/tasks3/db/models.py
@@ -1,4 +1,5 @@
 """Task database model"""
+import json
 import uuid
 
 from pathlib import Path
@@ -129,6 +130,10 @@ class Task(Base):
             description = self.description.replace("\n", "\n  ")
             yaml += f"description: >-\n  {description}\n"
         return yaml
+
+    def json(self) -> str:
+        """JSON representation of the task"""
+        return json.dumps(self.to_dict(), indent=2)
 
     def __repr__(self) -> str:
         return f"<Task{self.to_dict().__repr__()}>"

--- a/tasks3/tasks3.py
+++ b/tasks3/tasks3.py
@@ -44,6 +44,7 @@ def search(
         if description:
             query = query.filter(Task.description.contains(description))
         results = query.order_by(Task.urgency, Task.importance).all()
+        results.reverse()
         if tags:
             results = [task for task in results if set(tags) <= set(task.tags)]
         return results

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -34,21 +34,3 @@ def test_command_line_interface_main_help(cli_runner):
     help_result = cli_runner.invoke(cli.main, ["--help"])
     assert help_result.exit_code == 0
     assert "--help     Show this message and exit." in help_result.output
-
-
-def test_command_line_interface_task(cli_runner):
-    """Test the CLI (tasks3 task)"""
-    task_result = cli_runner.invoke(cli.main, ["task"])
-    assert task_result.exit_code == 0
-    assert cli.task.__doc__ in task_result.output
-    for command in cli.task.commands:
-        assert command in task_result.output
-
-
-def test_command_line_interface_task_help(cli_runner):
-    """Test the CLI (tasks3 task --help)"""
-    task_help_result = cli_runner.invoke(cli.main, ["task", "--help"])
-    assert task_help_result.exit_code == 0
-    assert cli.task.__doc__ in task_help_result.output
-    for command in cli.task.commands:
-        assert command in task_help_result.output


### PR DESCRIPTION
- Implement tasks3.search
- Implement cli for search.
- Add doc string for task.yaml
- Refactor out the formatter logic.
- Fix issue with paths that involve HOME (~)
- Implement cli for show
- Replace preferred_format with seperate configs.
- Fix tasks ordering.
- Update README for search and show functionality.
- Update HISTORY.rst
- Lint with black and flake8.
- Flatten the task command tree.
